### PR TITLE
Override toString for ATaggedVal

### DIFF
--- a/src/guten_tag/core.clj
+++ b/src/guten_tag/core.clj
@@ -51,7 +51,11 @@
   (assocEx [_ sk sv]
     (ATaggedVal. t (.assocEx v sk sv)))
   (without [_ sk]
-    (ATaggedVal. t (.without v sk))))
+    (ATaggedVal. t (.without v sk)))
+
+  Object
+  (toString [self]
+    (pr-str self)))
 
 (def ^:dynamic *concise-printing*
   true)


### PR DESCRIPTION
Without a custom toString method tagged vals look rather uninformative
when subjected to (str …). Improve this.
